### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+[![API Testing](https://img.shields.io/badge/test%20this%20API%20on-RapidAPI.com-blue.svg)](https://rapidapi.com/package/Twitter/functions?utm_source=GithubTwitter&utm_medium=button)
+
 twitterlibphp - Twitter/PHP interface
 http://jdp.github.com/twitterlibphp
 


### PR DESCRIPTION
I've added a link in your README to Twitter's functions page in RapidAPI. I've done this for a few Twitter SDKs to help those who are reading the READMEs, understand and test the API before use.